### PR TITLE
Add grpc transport

### DIFF
--- a/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatRequest.java
+++ b/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatRequest.java
@@ -8,6 +8,6 @@ import com.github.nhirakawa.wilson.models.style.WilsonStyle;
 @WilsonStyle
 @Immutable
 @JsonTypeName("Heartbeat")
-public interface HeartbeatMessage extends SerializedWilsonMessage {
+public interface HeartbeatRequest extends SerializedWilsonMessage {
 
 }

--- a/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatResponse.java
+++ b/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatResponse.java
@@ -1,0 +1,11 @@
+package com.github.nhirakawa.wilson.models.messages;
+
+import org.immutables.value.Value;
+
+import com.github.nhirakawa.wilson.models.style.WilsonStyle;
+
+@Value.Immutable
+@WilsonStyle
+public interface HeartbeatResponse extends SerializedWilsonMessage {
+
+}

--- a/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatTimeoutMessage.java
+++ b/core/src/main/java/com/github/nhirakawa/wilson/models/messages/HeartbeatTimeoutMessage.java
@@ -3,19 +3,18 @@ package com.github.nhirakawa.wilson.models.messages;
 import java.time.Instant;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Immutable;
 
 import com.github.nhirakawa.wilson.models.style.WilsonStyle;
 
-@Immutable
+@Value.Immutable
 @WilsonStyle
-public interface ElectionTimeoutMessage extends LocalWilsonMessage {
+public interface HeartbeatTimeoutMessage {
 
   @Value.Default
   default Instant getTimestamp() {
     return Instant.now();
   }
 
-  long getElectionTimeout();
+  long getHeartbeatTimeout();
 
 }

--- a/core/src/main/java/com/github/nhirakawa/wilson/models/messages/LeaderTimeoutMessage.java
+++ b/core/src/main/java/com/github/nhirakawa/wilson/models/messages/LeaderTimeoutMessage.java
@@ -16,4 +16,6 @@ public interface LeaderTimeoutMessage extends LocalWilsonMessage {
     return Instant.now();
   }
 
+  long getLeaderTimeout();
+
 }

--- a/core/src/main/java/com/github/nhirakawa/wilson/models/messages/SerializedWilsonMessage.java
+++ b/core/src/main/java/com/github/nhirakawa/wilson/models/messages/SerializedWilsonMessage.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @Type(value = ImmutableUuidWilsonMessage.class, name = "UuidMessage"),
     @Type(value = ImmutableAppendEntriesRequest.class, name = "AppendEntriesRequest"),
     @Type(value = ImmutableAppendEntriesResponse.class, name = "AppendEntriesResponse"),
-    @Type(value = ImmutableHeartbeatMessage.class, name = "Heartbeat"),
+    @Type(value = ImmutableHeartbeatRequest.class, name = "Heartbeat"),
     @Type(value = ImmutableVoteRequest.class, name = "VoteRequest"),
     @Type(value = ImmutableVoteResponse.class, name = "VoteResponse")
 })

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <assertj.version>3.8.0</assertj.version>
     <commons-cli.version>1.4</commons-cli.version>
     <grpc.version>1.5.0</grpc.version>
+    <guava-retrying.version>2.0.0</guava-retrying.version>
     <guava.version>23.0</guava.version>
     <guice.version>4.1.0</guice.version>
     <immutables.version>2.3.2</immutables.version>
@@ -25,7 +26,7 @@
     <log4j.version>2.7</log4j.version>
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.8.47</mockito.version>
-    <!--<netty.version>4.1.14.Final</netty.version>-->
+    <netty.version>4.1.12.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <protobuf.version>3.3.1</protobuf.version>
     <reflections.version>0.9.11</reflections.version>
@@ -78,7 +79,7 @@
       <dependency>
         <groupId>com.github.rholder</groupId>
         <artifactId>guava-retrying</artifactId>
-        <version>2.0.0</version>
+        <version>${guava-retrying.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -103,6 +104,11 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
         <version>${protobuf.version}</version>
       </dependency>
       <dependency>
@@ -131,10 +137,16 @@
         <version>${grpc.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.reflections</groupId>
         <artifactId>reflections</artifactId>
         <version>${reflections.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -196,6 +208,8 @@
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
+              <ignoreNonCompile>true</ignoreNonCompile>
+              <outputXML>true</outputXML>
             </configuration>
           </execution>
         </executions>
@@ -209,11 +223,13 @@
           <sortProperties>true</sortProperties>
           <keepBlankLines>true</keepBlankLines>
           <sortDependencies>scope,groupId,artifactId</sortDependencies>
+          <createBackupFile>false</createBackupFile>
+          <verifyFail>Stop</verifyFail>
         </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>sort</goal>
+              <goal>verify</goal>
             </goals>
             <phase>verify</phase>
           </execution>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>wilson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>2.0.2</version>
@@ -50,8 +54,20 @@
       <artifactId>guice</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -63,11 +79,19 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
@@ -78,8 +102,22 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/server/src/main/java/com/github/nhirakawa/server/WilsonRunner.java
+++ b/server/src/main/java/com/github/nhirakawa/server/WilsonRunner.java
@@ -2,14 +2,31 @@ package com.github.nhirakawa.server;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import com.github.nhirakawa.server.cli.CliArguments;
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.guice.WilsonConfigModule;
+import com.github.nhirakawa.server.guice.WilsonRaftModule;
+import com.github.nhirakawa.server.guice.WilsonTransportModule;
+import com.github.nhirakawa.server.transport.WilsonServer;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Stage;
 
 public class WilsonRunner {
 
@@ -19,7 +36,15 @@ public class WilsonRunner {
     CliArguments cliArguments = new CliArguments(args);
     loadProperties(cliArguments);
 
-    System.exit(0);
+    Injector parentInjector = Guice.createInjector(Stage.PRODUCTION, new WilsonConfigModule(cliArguments));
+    Configuration configuration = parentInjector.getInstance(Configuration.class);
+
+    if (cliArguments.isLocalMode()) {
+      run(configuration.getClusterMembers(), parentInjector);
+    } else {
+      Preconditions.checkState(configuration.getLocalMember().isPresent(), "Not running in local mode, but no local member specified");
+      run(Collections.singleton(configuration.getLocalMember().get()), parentInjector);
+    }
   }
 
   private static void loadProperties(CliArguments cliArguments) throws IOException {
@@ -36,5 +61,39 @@ public class WilsonRunner {
     for (Entry<Object, Object> entry : properties.entrySet()) {
       systemProperties.putIfAbsent(entry.getKey(), entry.getValue());
     }
+  }
+
+  private static void run(Collection<? extends ClusterMember> members,
+                          Injector parentInjector) {
+    ExecutorService executorService = getExecutorService();
+    for (ClusterMember member : members) {
+      executorService.submit(() -> runMember(member, parentInjector));
+    }
+  }
+
+  private static void runMember(ClusterMember clusterMember,
+                                Injector parentInjector) {
+    MDC.put("serverId", clusterMember.getServerId());
+    WilsonRaftModule wilsonRaftModule = new WilsonRaftModule(clusterMember.getServerId());
+    Injector injector = parentInjector.createChildInjector(wilsonRaftModule, new WilsonTransportModule(clusterMember));
+
+    try {
+      injector.getInstance(WilsonServer.class).start();
+    } catch (InterruptedException | IOException e) {
+      LOG.error("Could not bootstrap {}", clusterMember, e);
+      throw new RuntimeException(e);
+    } finally {
+      MDC.remove("serverId");
+    }
+  }
+
+  private static ExecutorService getExecutorService() {
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("wilson-runner-%s")
+        .setDaemon(false)
+        .setUncaughtExceptionHandler((t, e) -> LOG.error("Uncaught exception in thread {}", t, e))
+        .build();
+
+    return Executors.newFixedThreadPool(10, threadFactory);
   }
 }

--- a/server/src/main/java/com/github/nhirakawa/server/cli/CliOption.java
+++ b/server/src/main/java/com/github/nhirakawa/server/cli/CliOption.java
@@ -16,25 +16,30 @@ public enum CliOption {
           .type(String.class)
           .build()
   ),
-  DEVELOPMENT_MODE(
-      Option.builder("d")
-          .argName("developmentMode")
-          .longOpt("development-mode")
-          .desc("Allow extra configuration options for local development")
+
+  HOST(
+      Option.builder("host")
+          .argName("host")
+          .longOpt("host")
+          .desc("Host of local cluster member")
           .required(false)
-          .hasArg(false)
+          .hasArg()
+          .numberOfArgs(1)
+          .type(String.class)
           .build()
   ),
-  LOCAL_PORTS(
-      Option.builder("p")
-          .argName("localPorts")
-          .longOpt("local-ports")
-          .desc("Specify ports for multiple cluster members (in development mode only)")
-          .required(false)
-          .hasArgs()
-          .valueSeparator(',')
+
+  PORT(
+      Option.builder("port")
+          .argName("port")
+          .longOpt("port")
+          .desc("Port of local cluster member")
+          .hasArg()
+          .numberOfArgs(1)
+          .type(Integer.class)
           .build()
   ),
+
   LOCAL_MODE(
       Option.builder("local")
           .argName("local mode")

--- a/server/src/main/java/com/github/nhirakawa/server/config/ClusterMember.java
+++ b/server/src/main/java/com/github/nhirakawa/server/config/ClusterMember.java
@@ -1,13 +1,12 @@
 package com.github.nhirakawa.server.config;
 
-import java.nio.charset.StandardCharsets;
+import java.net.InetSocketAddress;
 
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 
 import com.github.nhirakawa.wilson.models.style.WilsonStyle;
-import com.google.common.hash.Hashing;
 
 @Immutable
 @WilsonStyle
@@ -22,10 +21,6 @@ public abstract class ClusterMember {
 
   @Derived
   public String getServerId() {
-    return Hashing.murmur3_128().newHasher()
-        .putString(getHost(), StandardCharsets.UTF_8)
-        .putInt(getPort())
-        .hash()
-        .toString();
+    return InetSocketAddress.createUnresolved(getHost(), getPort()).toString();
   }
 }

--- a/server/src/main/java/com/github/nhirakawa/server/config/Configuration.java
+++ b/server/src/main/java/com/github/nhirakawa/server/config/Configuration.java
@@ -1,22 +1,23 @@
 package com.github.nhirakawa.server.config;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Auxiliary;
 import org.immutables.value.Value.Default;
-import org.immutables.value.Value.Derived;
-import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Lazy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.nhirakawa.wilson.models.style.WilsonStyle;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
-@Immutable
+@Value.Immutable
 @WilsonStyle
 public interface Configuration {
 
@@ -28,26 +29,29 @@ public interface Configuration {
   @Default
   @JsonProperty("cluster")
   default Set<ImmutableClusterMember> getClusterMembers() {
-    return Collections.singleton(getLocalMember());
+    return Collections.singleton(
+        ImmutableClusterMember.builder()
+            .setHost("localhost")
+            .setPort(8080)
+            .build()
+    );
   }
 
-  @Default
-  @JsonProperty("local")
-  default ImmutableClusterMember getLocalMember() {
-    return ImmutableClusterMember.builder()
-        .setHost("localhost")
-        .setPort(8080)
-        .build();
-  }
+  Optional<ImmutableClusterMember> getLocalMember();
 
   @Default
   default long getLeaderTimeout() {
-    return 100L;
+    return 1000L;
   }
 
   @Default
   default long getElectionTimeout() {
-    return 500L;
+    return 2000L;
+  }
+
+  @Default
+  default long getHeartbeatTimeout() {
+    return 250L;
   }
 
   @Default
@@ -55,18 +59,29 @@ public interface Configuration {
     return 10;
   }
 
-  @Derived
-  default Collection<ImmutableClusterMember> getPeers() {
-    return getClusterMembers().stream()
-        .filter(serverInfo -> !serverInfo.equals(getLocalMember()))
-        .collect(Collectors.toSet());
-  }
-
   @Lazy
   default Set<String> getClusterServerIds() {
     return getClusterMembers().stream()
         .map(ClusterMember::getServerId)
         .collect(ImmutableSet.toImmutableSet());
+  }
+
+  @Auxiliary
+  @JsonIgnore
+  default Random getRandom() {
+    return new Random();
+  }
+
+  default long getLeaderTimeoutWithJitter() {
+    return getLeaderTimeout() + ThreadLocalRandom.current().nextLong(50, 100);
+  }
+
+  default long getElectionTimeoutWithJitter() {
+    return getElectionTimeout() + ThreadLocalRandom.current().nextLong(100, 200);
+  }
+
+  default long getHeartbeatTimeoutWithJitter() {
+    return getHeartbeatTimeout() + ThreadLocalRandom.current().nextLong(25, 50);
   }
 
   @Auxiliary

--- a/server/src/main/java/com/github/nhirakawa/server/guice/ClientWorkerGroup.java
+++ b/server/src/main/java/com/github/nhirakawa/server/guice/ClientWorkerGroup.java
@@ -1,0 +1,14 @@
+package com.github.nhirakawa.server.guice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+@BindingAnnotation
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClientWorkerGroup {
+}

--- a/server/src/main/java/com/github/nhirakawa/server/guice/ServerBossGroup.java
+++ b/server/src/main/java/com/github/nhirakawa/server/guice/ServerBossGroup.java
@@ -1,0 +1,14 @@
+package com.github.nhirakawa.server.guice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+@BindingAnnotation
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ServerBossGroup {
+}

--- a/server/src/main/java/com/github/nhirakawa/server/guice/ServerWorkerGroup.java
+++ b/server/src/main/java/com/github/nhirakawa/server/guice/ServerWorkerGroup.java
@@ -1,0 +1,14 @@
+package com.github.nhirakawa.server.guice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+@BindingAnnotation
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ServerWorkerGroup {
+}

--- a/server/src/main/java/com/github/nhirakawa/server/guice/WilsonTransportModule.java
+++ b/server/src/main/java/com/github/nhirakawa/server/guice/WilsonTransportModule.java
@@ -1,0 +1,162 @@
+package com.github.nhirakawa.server.guice;
+
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.github.nhirakawa.server.cli.CliArguments;
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.config.ImmutableClusterMember;
+import com.github.nhirakawa.server.transport.grpc.SocketAddressProvider;
+import com.github.nhirakawa.server.transport.grpc.WilsonGrpcClient.WilsonGrpcClientFactory;
+import com.github.nhirakawa.server.transport.grpc.WilsonGrpcClientAdapter;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.Multibinder;
+import com.google.protobuf.util.JsonFormat;
+
+import io.grpc.BindableService;
+import io.grpc.Server;
+import io.grpc.ServerInterceptor;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+public class WilsonTransportModule extends AbstractModule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WilsonTransportModule.class);
+
+  private final ClusterMember localMember;
+
+  public WilsonTransportModule(ClusterMember localMember) {
+    this.localMember = localMember;
+  }
+
+  @Override
+  protected void configure() {
+    Multibinder<BindableService> serviceMultibinder = Multibinder.newSetBinder(binder(), BindableService.class);
+    Reflections reflections = new Reflections("com.github.nhirakawa.server");
+    reflections.getSubTypesOf(BindableService.class).stream()
+        .filter(this::isConcreteClass)
+        .peek(this::logBindableService)
+        .forEach(clazz -> serviceMultibinder.addBinding().to(clazz));
+
+    Multibinder<ServerInterceptor> serverInterceptorMultiBinder = Multibinder.newSetBinder(binder(), ServerInterceptor.class);
+    reflections.getSubTypesOf(ServerInterceptor.class).stream()
+        .filter(this::isConcreteClass)
+        .peek(this::logServerInterceptor)
+        .forEach(clazz -> serverInterceptorMultiBinder.addBinding().to(clazz));
+
+    install(new FactoryModuleBuilder().build(WilsonGrpcClientFactory.class));
+
+    bind(WilsonGrpcClientAdapter.class).asEagerSingleton();
+    bind(Key.get(ClusterMember.class, LocalMember.class)).toInstance(localMember);
+    bind(JsonFormat.Printer.class).toInstance(JsonFormat.printer().includingDefaultValueFields());
+    bind(EventBus.class).toInstance(new EventBus());
+  }
+
+  @Provides
+  @Singleton
+  ObjectMapper provideObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new GuavaModule());
+    return objectMapper;
+  }
+
+  @Provides
+  @Singleton
+  ScheduledExecutorService provideScheduledExecutorService() {
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(
+        4,
+        getNamedThreadFactory("wilson-scheduled")
+    );
+    return executor;
+  }
+
+  @Provides
+  @Singleton
+  Retryer<Void> provideRetyrer() {
+    return RetryerBuilder.<Void>newBuilder()
+        .withWaitStrategy(WaitStrategies.fixedWait(5L, TimeUnit.SECONDS))
+//        .withStopStrategy(StopStrategies.stopAfterAttempt(10))
+        .build();
+  }
+
+  @Provides
+  @Singleton
+  Server provideServer(CliArguments cliArguments,
+                       SocketAddressProvider socketAddressProvider,
+                       Configuration configuration,
+                       Set<BindableService> services,
+                       Set<ServerInterceptor> serverInterceptors,
+                       @LocalMember ClusterMember clusterMember) {
+    if (cliArguments.isLocalMode()) {
+      InProcessServerBuilder builder = InProcessServerBuilder.forName(clusterMember.getServerId());
+      services.forEach(builder::addService);
+      serverInterceptors.forEach(builder::intercept);
+      return builder.build();
+    } else {
+      NettyServerBuilder builder = NettyServerBuilder.forAddress(socketAddressProvider.getSocketAddressFor(clusterMember));
+      builder.channelType(NioServerSocketChannel.class);
+      services.forEach(builder::addService);
+      serverInterceptors.forEach(builder::intercept);
+      return builder.build();
+    }
+
+//    NettyServerBuilder builder = NettyServerBuilder.forAddress(socketAddressProvider.getSocketAddressFor(clusterMember));
+//    if (cliArguments.isLocalMode()) {
+//      builder.channelType(LocalServerChannel.class);
+//    } else {
+//      builder.channelType(NioServerSocketChannel.class);
+//    }
+//    services.forEach(builder::addService);
+//    serverInterceptors.forEach(builder::intercept);
+//    return builder.build();
+  }
+
+  @Provides
+  @Singleton
+  Set<ImmutableClusterMember> providePeers(Configuration configuration,
+                                           @LocalMember ClusterMember clusterMember) {
+    return configuration.getClusterMembers().stream()
+        .filter(member -> !member.equals(clusterMember))
+        .collect(ImmutableSet.toImmutableSet());
+  }
+
+  private boolean isConcreteClass(Class<?> clazz) {
+    return !clazz.isInterface() && !Modifier.isAbstract(clazz.getModifiers());
+  }
+
+  private void logBindableService(Class<?> clazz) {
+    LOG.debug("Found BindableServce {}", clazz.getCanonicalName());
+  }
+
+  private void logServerInterceptor(Class<?> clazz) {
+    LOG.debug("Found ServerInterceptor {}", clazz.getCanonicalName());
+  }
+
+  private static ThreadFactory getNamedThreadFactory(String namespace) {
+    return new ThreadFactoryBuilder()
+        .setNameFormat(namespace + "-%s")
+        .build();
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/raft/WilsonState.java
+++ b/server/src/main/java/com/github/nhirakawa/server/raft/WilsonState.java
@@ -5,31 +5,32 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.immutables.value.Value.Default;
-import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Lazy;
+import org.immutables.value.Value;
 
 import com.github.nhirakawa.server.config.ClusterMember;
 import com.github.nhirakawa.wilson.models.style.WilsonStyle;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 
-@Immutable
+@Value.Immutable
 @WilsonStyle
 public interface WilsonState {
 
-  @Default
+  @Value.Default
   default long getCurrentTerm() {
     return 1L;
   }
 
-  @Default
+  @Value.Default
   default Instant getLastHeartbeatReceived() {
     return Instant.now();
   }
 
   Optional<Instant> getLastElectionStarted();
 
-  @Default
+  Optional<ClusterMember> getCurrentLeader();
+
+  @Value.Default
   default LeaderState getLeaderState() {
     return LeaderState.FOLLOWER;
   }
@@ -40,16 +41,35 @@ public interface WilsonState {
 
   Set<ClusterMember> getVotesReceivedFrom();
 
-  @Lazy
+  @Value.Lazy
   default long getLastLogTerm() {
     Optional<LogItem> maybeLogItem = Optional.ofNullable(Iterables.getLast(getLog(), null));
     return maybeLogItem.map(LogItem::getTerm).orElse(1L);
   }
 
-  @Lazy
+  @Value.Lazy
   default long getLastLogIndex() {
     Optional<LogItem> maybeLogItem = Optional.ofNullable(Iterables.getLast(getLog(), null));
     return maybeLogItem.map(LogItem::getIndex).orElse(1L);
+  }
+
+  @Value.Check
+  default void check() {
+    Preconditions.checkState(getCurrentTerm() >= 0, "current term must be >= 0");
+    Preconditions.checkState(getLastLogTerm() >= 0, "last log term must be >= 0");
+    Preconditions.checkState(getLastLogIndex() >= 0, "last log index must be >= 0");
+
+    if (getLeaderState() == LeaderState.FOLLOWER) {
+
+    } else if (getLeaderState() == LeaderState.CANDIDATE) {
+      Preconditions.checkState(!getVotesReceivedFrom().isEmpty(), "must have at least one vote if I am candidate");
+      Preconditions.checkState(getLastVotedFor().isPresent(), "must have voted for myself if I am candidate");
+      Preconditions.checkState(getLastElectionStarted().isPresent(), "election must have started if I am candidate");
+    } else if (getLeaderState() == LeaderState.LEADER) {
+      Preconditions.checkState(!getLastElectionStarted().isPresent(), "last election cannot be set when leader");
+      Preconditions.checkState(!getLastVotedFor().isPresent(), "cannot have outstanding vote when leader");
+      Preconditions.checkState(getCurrentLeader().isPresent(), "current leader must be set because I am leader");
+    }
   }
 
 }

--- a/server/src/main/java/com/github/nhirakawa/server/timeout/BaseTimeout.java
+++ b/server/src/main/java/com/github/nhirakawa/server/timeout/BaseTimeout.java
@@ -7,7 +7,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.guice.LocalMember;
 import com.google.common.base.Preconditions;
 
 abstract class BaseTimeout {
@@ -18,18 +21,25 @@ abstract class BaseTimeout {
 
   private final ScheduledExecutorService scheduledExecutorService;
   private final long period;
+  private final String serverId;
 
   private Optional<ScheduledFuture<?>> scheduledFuture;
 
   protected BaseTimeout(ScheduledExecutorService scheduledExecutorService,
-                        long period) {
+                        long period,
+                        @LocalMember ClusterMember clusterMember) {
     this.scheduledExecutorService = scheduledExecutorService;
     this.period = period;
+    this.serverId = clusterMember.getServerId();
 
     this.scheduledFuture = Optional.empty();
   }
 
   protected abstract void doTimeout() throws Exception;
+
+  protected long getPeriod() {
+    return period;
+  }
 
   public void start() {
     Preconditions.checkState(
@@ -53,10 +63,13 @@ abstract class BaseTimeout {
   }
 
   private void doSafeTimeout() {
+    MDC.put("serverId", serverId);
     try {
       doTimeout();
     } catch (Exception e) {
       LOG.error("Timeout encountered exception", e);
+    } finally {
+      MDC.remove("serverId");
     }
   }
 }

--- a/server/src/main/java/com/github/nhirakawa/server/timeout/ElectionTimeout.java
+++ b/server/src/main/java/com/github/nhirakawa/server/timeout/ElectionTimeout.java
@@ -2,26 +2,39 @@ package com.github.nhirakawa.server.timeout;
 
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.nhirakawa.server.config.ClusterMember;
 import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.guice.LocalMember;
 import com.github.nhirakawa.server.raft.StateMachineMessageApplier;
+import com.github.nhirakawa.wilson.models.messages.ImmutableElectionTimeoutMessage;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
 public class ElectionTimeout extends BaseTimeout {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ElectionTimeout.class);
+
   private final StateMachineMessageApplier messageApplier;
 
   @Inject
   ElectionTimeout(ScheduledExecutorService scheduledExecutorService,
                   Configuration configuration,
-                  StateMachineMessageApplier messageApplier) {
-    super(scheduledExecutorService, configuration.getElectionTimeout());
+                  StateMachineMessageApplier messageApplier,
+                  @LocalMember ClusterMember clusterMember) {
+    super(scheduledExecutorService, configuration.getElectionTimeoutWithJitter(), clusterMember);
     this.messageApplier = messageApplier;
   }
 
   @Override
-  protected void doTimeout() throws Exception {
-
+  protected void doTimeout() {
+    messageApplier.apply(
+        ImmutableElectionTimeoutMessage.builder()
+            .setElectionTimeout(getPeriod())
+            .build()
+    );
   }
 }

--- a/server/src/main/java/com/github/nhirakawa/server/timeout/HeartbeatTimeout.java
+++ b/server/src/main/java/com/github/nhirakawa/server/timeout/HeartbeatTimeout.java
@@ -1,0 +1,33 @@
+package com.github.nhirakawa.server.timeout;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.guice.LocalMember;
+import com.github.nhirakawa.server.raft.StateMachineMessageApplier;
+import com.github.nhirakawa.wilson.models.messages.ImmutableHeartbeatTimeoutMessage;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class HeartbeatTimeout extends BaseTimeout {
+
+  private final StateMachineMessageApplier applier;
+
+  @Inject
+  HeartbeatTimeout(ScheduledExecutorService scheduledExecutorService,
+                   Configuration configuration,
+                   StateMachineMessageApplier applier,
+                   @LocalMember ClusterMember clusterMember) {
+    super(scheduledExecutorService, configuration.getHeartbeatTimeoutWithJitter(), clusterMember);
+    this.applier = applier;
+  }
+
+  @Override
+  protected void doTimeout() {
+    applier.apply(ImmutableHeartbeatTimeoutMessage.builder()
+        .setHeartbeatTimeout(getPeriod())
+        .build());
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/WilsonServer.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/WilsonServer.java
@@ -1,0 +1,48 @@
+package com.github.nhirakawa.server.transport;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.guice.LocalMember;
+import com.github.nhirakawa.server.timeout.ElectionTimeout;
+import com.github.nhirakawa.server.timeout.HeartbeatTimeout;
+import com.github.nhirakawa.server.timeout.LeaderTimeout;
+import com.google.inject.Inject;
+
+import io.grpc.Server;
+
+public class WilsonServer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WilsonServer.class);
+
+  private final Server server;
+  private final LeaderTimeout leaderTimeout;
+  private final ElectionTimeout electionTimeout;
+  private final HeartbeatTimeout heartbeatTimeout;
+  private final ClusterMember clusterMember;
+
+  @Inject
+  public WilsonServer(Server server,
+                      LeaderTimeout leaderTimeout,
+                      ElectionTimeout electionTimeout,
+                      HeartbeatTimeout heartbeatTimeout,
+                      @LocalMember ClusterMember clusterMember) {
+    this.server = server;
+    this.leaderTimeout = leaderTimeout;
+    this.electionTimeout = electionTimeout;
+    this.heartbeatTimeout = heartbeatTimeout;
+    this.clusterMember = clusterMember;
+  }
+
+  public void start() throws InterruptedException, IOException {
+    server.start();
+    LOG.info("Wilson grpc server started for {}", clusterMember.getServerId());
+    leaderTimeout.start();
+    electionTimeout.start();
+    heartbeatTimeout.start();
+    server.awaitTermination();
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/ProtobufTranslator.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/ProtobufTranslator.java
@@ -1,0 +1,48 @@
+package com.github.nhirakawa.server.transport.grpc;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.nhirakawa.wilson.models.messages.HeartbeatRequest;
+import com.github.nhirakawa.wilson.models.messages.HeartbeatResponse;
+import com.github.nhirakawa.wilson.models.messages.ImmutableHeartbeatResponse;
+import com.github.nhirakawa.wilson.models.messages.ImmutableVoteResponse;
+import com.github.nhirakawa.wilson.models.messages.VoteRequest;
+import com.github.nhirakawa.wilson.models.messages.VoteResponse;
+import com.google.inject.Inject;
+
+final class ProtobufTranslator {
+
+  private final ObjectMapper objectMapper;
+
+  @Inject
+  ProtobufTranslator(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public static WilsonProtos.VoteRequest toProto(VoteRequest request) {
+    return WilsonProtos.VoteRequest.newBuilder()
+        .setTerm(request.getTerm())
+        .setLastLogTerm(request.getLastLogTerm())
+        .setLastLogIndex(request.getLastLogIndex())
+        .setTimestamp(Instant.now().toEpochMilli())
+        .build();
+  }
+
+  public static VoteResponse fromProto(WilsonProtos.VoteResponse voteResponse) {
+    return ImmutableVoteResponse.builder()
+        .setTerm(voteResponse.getCurrentTerm())
+        .setVoteGranted(voteResponse.getVoteGranted())
+        .build();
+  }
+
+  public static WilsonProtos.HeartbeatRequest toProto(HeartbeatRequest heartbeatRequest) {
+    return WilsonProtos.HeartbeatRequest.newBuilder()
+        .setTimestamp(Instant.now().toEpochMilli())
+        .build();
+  }
+
+  public static HeartbeatResponse fromProto(WilsonProtos.HeartbeatResponse heartbeatResponse) {
+    return ImmutableHeartbeatResponse.builder().build();
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/SocketAddressProvider.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/SocketAddressProvider.java
@@ -1,0 +1,36 @@
+package com.github.nhirakawa.server.transport.grpc;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.github.nhirakawa.server.cli.CliArguments;
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.google.inject.Inject;
+
+import io.grpc.inprocess.InProcessSocketAddress;
+
+public class SocketAddressProvider {
+
+  private final boolean isLocalMode;
+  private final Map<ClusterMember, SocketAddress> socketAddressMap;
+
+  @Inject
+  SocketAddressProvider(CliArguments cliArguments) {
+    this.isLocalMode = cliArguments.isLocalMode();
+    this.socketAddressMap = new ConcurrentHashMap<>();
+  }
+
+  public SocketAddress getSocketAddressFor(ClusterMember clusterMember) {
+    return socketAddressMap.computeIfAbsent(clusterMember, this::getSocketAddress);
+  }
+
+  private SocketAddress getSocketAddress(ClusterMember clusterMember) {
+    if (isLocalMode) {
+      return new InProcessSocketAddress(clusterMember.getServerId());
+    } else {
+      return new InetSocketAddress(clusterMember.getHost(), clusterMember.getPort());
+    }
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcClient.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcClient.java
@@ -1,0 +1,82 @@
+package com.github.nhirakawa.server.transport.grpc;
+
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import com.github.nhirakawa.server.cli.CliArguments;
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.transport.grpc.intercept.ClientHeaderInterceptor;
+import com.github.nhirakawa.wilson.models.messages.HeartbeatRequest;
+import com.github.nhirakawa.wilson.models.messages.HeartbeatResponse;
+import com.github.nhirakawa.wilson.models.messages.VoteRequest;
+import com.github.nhirakawa.wilson.models.messages.VoteResponse;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import com.google.protobuf.GeneratedMessageV3;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.netty.NettyChannelBuilder;
+
+public class WilsonGrpcClient {
+
+  private final WilsonGrpc.WilsonBlockingStub stub;
+  private final WilsonGrpc.WilsonFutureStub futureStub;
+
+  @AssistedInject
+  WilsonGrpcClient(@Assisted ClusterMember clusterMember,
+                   ClientHeaderInterceptor clientHeaderInterceptor,
+                   CliArguments cliArguments,
+                   SocketAddressProvider socketAddressProvider) {
+    ManagedChannelBuilder<?> channelBuilder = cliArguments.isLocalMode()
+        ? InProcessChannelBuilder.forName(clusterMember.getServerId())
+        : NettyChannelBuilder.forAddress(socketAddressProvider.getSocketAddressFor(clusterMember));
+//    ManagedChannelBuilder<?> channelBuilder = NettyChannelBuilder.forAddress(socketAddressProvider.getSocketAddressFor(clusterMember));
+
+    ManagedChannel channel = channelBuilder
+        .intercept(clientHeaderInterceptor)
+        .usePlaintext(true)
+        .userAgent("Wilson/1.0")
+        .build();
+
+    this.stub = WilsonGrpc.newBlockingStub(channel);
+    this.futureStub = WilsonGrpc.newFutureStub(channel);
+  }
+
+  public VoteResponse requestVoteSync(VoteRequest voteRequest) {
+    WilsonProtos.VoteRequest protoVoteRequest = ProtobufTranslator.toProto(voteRequest);
+    WilsonProtos.VoteResponse protoVoteResponse = stub.requestVote(protoVoteRequest);
+    return ProtobufTranslator.fromProto(protoVoteResponse);
+  }
+
+  public HeartbeatResponse sendHeartbeatSync(HeartbeatRequest heartbeatRequest) {
+    WilsonProtos.HeartbeatRequest protoHeartbeatRequest = ProtobufTranslator.toProto(heartbeatRequest);
+    WilsonProtos.HeartbeatResponse protoHeartbeatResponse = stub.heartbeat(protoHeartbeatRequest);
+    return ProtobufTranslator.fromProto(protoHeartbeatResponse);
+  }
+
+  private static <T extends GeneratedMessageV3> CompletableFuture<T> fromListenableFuture(ListenableFuture<T> future) {
+    CompletableFuture<T> completableFuture = new CompletableFuture<>();
+    Futures.addCallback(future, new FutureCallback<T>() {
+      @Override
+      public void onSuccess(@Nullable T result) {
+        completableFuture.complete(result);
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        completableFuture.completeExceptionally(t);
+      }
+    });
+    return completableFuture;
+  }
+
+  public interface WilsonGrpcClientFactory {
+    WilsonGrpcClient create(ClusterMember clusterMember);
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcClientAdapter.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcClientAdapter.java
@@ -1,0 +1,137 @@
+package com.github.nhirakawa.server.transport.grpc;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.nhirakawa.server.cli.CliArguments;
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.config.ImmutableClusterMember;
+import com.github.nhirakawa.server.raft.StateMachineMessageApplier;
+import com.github.nhirakawa.server.transport.grpc.WilsonGrpcClient.WilsonGrpcClientFactory;
+import com.github.nhirakawa.wilson.models.messages.HeartbeatRequest;
+import com.github.nhirakawa.wilson.models.messages.ImmutableHeartbeatRequest;
+import com.github.nhirakawa.wilson.models.messages.SerializedWilsonMessage;
+import com.github.nhirakawa.wilson.models.messages.VoteRequest;
+import com.github.nhirakawa.wilson.models.messages.VoteResponse;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.google.common.eventbus.DeadEvent;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class WilsonGrpcClientAdapter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WilsonGrpcClientAdapter.class);
+
+  private static final String THREAD_NAME_FORMAT = "WilsonGrpcClientAdapter-%s";
+  private static final ThreadFactory THREAD_FACTORY = new ThreadFactoryBuilder().setNameFormat(THREAD_NAME_FORMAT).build();
+
+  private final WilsonGrpcClientFactory clientFactory;
+  private final SocketAddressProvider socketAddressProvider;
+  private final Configuration configuration;
+  private final Set<ImmutableClusterMember> peers;
+  private final CliArguments cliArguments;
+  private final StateMachineMessageApplier messageApplier;
+
+  private final Map<ClusterMember, WilsonGrpcClient> clientMap;
+  private final ExecutorService executorService;
+  private final Retryer<? super SerializedWilsonMessage> retryer;
+
+  @Inject
+  WilsonGrpcClientAdapter(WilsonGrpcClientFactory clientFactory,
+                          SocketAddressProvider socketAddressProvider,
+                          Configuration configuration,
+                          EventBus eventBus,
+                          Set<ImmutableClusterMember> peers,
+                          CliArguments cliArguments,
+                          StateMachineMessageApplier messageApplier) {
+    this.clientFactory = clientFactory;
+    this.socketAddressProvider = socketAddressProvider;
+    this.configuration = configuration;
+    this.peers = peers;
+    this.cliArguments = cliArguments;
+    this.messageApplier = messageApplier;
+
+    this.clientMap = new ConcurrentHashMap<>();
+    this.executorService = Executors.newFixedThreadPool(configuration.getNumClientThreads(), THREAD_FACTORY);
+    this.retryer = RetryerBuilder.<SerializedWilsonMessage>newBuilder()
+        .retryIfException()
+        .withStopStrategy(StopStrategies.stopAfterDelay(1L, TimeUnit.SECONDS))
+        .withWaitStrategy(WaitStrategies.fixedWait(1000L, TimeUnit.MILLISECONDS))
+        .build();
+
+    eventBus.register(this);
+  }
+
+  @Subscribe
+  public void handleDeadEvent(DeadEvent deadEvent) {
+    LOG.debug("Found DeadEvent {}", deadEvent);
+  }
+
+  @Subscribe
+  public void broadcastVoteRequest(VoteRequest voteRequest) {
+    for (ClusterMember clusterMember : peers) {
+      requestVoteWithRetries(voteRequest, clusterMember);
+    }
+  }
+
+  private void requestVoteWithRetries(VoteRequest voteRequest, ClusterMember clusterMember) {
+    try {
+      VoteResponse voteResponse = (VoteResponse) retryer.call(() -> requestVote(clusterMember, voteRequest));
+      messageApplier.apply(voteResponse, clusterMember);
+    } catch (ExecutionException | RetryException e) {
+      Throwable cause = e.getCause();
+      LOG.error("Encountered exception while requesting vote ({}: {})", cause.getClass().getSimpleName(), cause.getMessage(), cause);
+    }
+  }
+
+  private VoteResponse requestVote(ClusterMember clusterMember,
+                                   VoteRequest voteRequest) {
+    WilsonGrpcClient client = getClientForMember(clusterMember);
+    VoteResponse voteResponse = client.requestVoteSync(voteRequest);
+    return voteResponse;
+  }
+
+  @Subscribe
+  public void broadcastHeartbeat(ImmutableHeartbeatRequest heartbeatRequest) {
+    for (ClusterMember clusterMember : peers) {
+      LOG.debug("Sending heartbeat to {}", clusterMember);
+      sendHeartbeatWithRetries(heartbeatRequest, clusterMember);
+    }
+  }
+
+  private void sendHeartbeatWithRetries(HeartbeatRequest message, ClusterMember clusterMember) {
+    WilsonGrpcClient client = getClientForMember(clusterMember);
+    try {
+      retryer.call(() -> client.sendHeartbeatSync(message));
+    } catch (ExecutionException | RetryException e) {
+      Throwable cause = e.getCause();
+      LOG.error("Encountered exception while requesting vote ({}: {})", cause.getClass().getSimpleName(), cause.getMessage());
+    }
+  }
+
+  private WilsonGrpcClient getClientForMember(ClusterMember clusterMember) {
+    return clientMap.computeIfAbsent(clusterMember, this::getClient);
+  }
+
+  private WilsonGrpcClient getClient(ClusterMember clusterMember) {
+    return clientFactory.create(clusterMember);
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcService.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/WilsonGrpcService.java
@@ -1,0 +1,87 @@
+package com.github.nhirakawa.server.transport.grpc;
+
+import java.util.UUID;
+
+import org.slf4j.MDC;
+
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.ImmutableClusterMember;
+import com.github.nhirakawa.server.guice.LocalMember;
+import com.github.nhirakawa.server.raft.StateMachineMessageApplier;
+import com.github.nhirakawa.server.transport.grpc.WilsonProtos.HeartbeatRequest;
+import com.github.nhirakawa.server.transport.grpc.WilsonProtos.HeartbeatResponse;
+import com.github.nhirakawa.server.transport.grpc.WilsonProtos.UuidRequest;
+import com.github.nhirakawa.server.transport.grpc.WilsonProtos.UuidResponse;
+import com.github.nhirakawa.wilson.models.messages.ImmutableHeartbeatRequest;
+import com.github.nhirakawa.wilson.models.messages.ImmutableVoteRequest;
+import com.github.nhirakawa.wilson.models.messages.VoteRequest;
+import com.github.nhirakawa.wilson.models.messages.VoteResponse;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import io.grpc.stub.StreamObserver;
+
+@Singleton
+public class WilsonGrpcService extends WilsonGrpc.WilsonImplBase {
+
+  private final StateMachineMessageApplier messageApplier;
+  private final ClusterMember localMember;
+
+  @Inject
+  WilsonGrpcService(StateMachineMessageApplier messageApplier,
+                    @LocalMember ClusterMember localMember) {
+    this.messageApplier = messageApplier;
+    this.localMember = localMember;
+  }
+
+  @Override
+  public void uuid(UuidRequest request, StreamObserver<UuidResponse> responseObserver) {
+    MDC.put("serverId", localMember.getServerId());
+    UuidResponse response = UuidResponse.newBuilder()
+        .setId(UUID.randomUUID().toString())
+        .build();
+
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+    MDC.remove("serverId");
+  }
+
+  @Override
+  public void heartbeat(HeartbeatRequest request, StreamObserver<HeartbeatResponse> responseObserver) {
+    MDC.put("serverId", localMember.getServerId());
+    ImmutableHeartbeatRequest heartbeatRequest = ImmutableHeartbeatRequest.builder().build();
+    messageApplier.apply(heartbeatRequest);
+    responseObserver.onNext(HeartbeatResponse.getDefaultInstance());
+    responseObserver.onCompleted();
+    MDC.remove("serverId");
+  }
+
+  @Override
+  public void requestVote(WilsonProtos.VoteRequest request, StreamObserver<WilsonProtos.VoteResponse> responseObserver) {
+    MDC.put("serverId", localMember.getServerId());
+    ClusterMember clusterMember = ImmutableClusterMember.builder()
+        .setHost(request.getClusterMember().getHost())
+        .setPort(request.getClusterMember().getPort())
+        .build();
+    VoteRequest voteRequest = ImmutableVoteRequest.builder()
+        .setTerm(request.getTerm())
+        .setLastLogTerm(request.getLastLogTerm())
+        .setLastLogIndex(request.getLastLogIndex())
+        .build();
+
+    VoteResponse voteResponse = messageApplier.apply(voteRequest, clusterMember);
+
+    WilsonProtos.VoteResponse response = WilsonProtos.VoteResponse.newBuilder()
+        .setClusterMember(
+            WilsonProtos.ClusterMember.newBuilder()
+            .setHost(localMember.getHost())
+            .setPort(localMember.getPort())
+        )
+        .setVoteGranted(voteResponse.isVoteGranted())
+        .setCurrentTerm(voteResponse.getTerm())
+        .build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+    MDC.remove("serverId");
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/ClientHeaderInterceptor.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/ClientHeaderInterceptor.java
@@ -1,0 +1,41 @@
+package com.github.nhirakawa.server.transport.grpc.intercept;
+
+import com.github.nhirakawa.server.config.ClusterMember;
+import com.github.nhirakawa.server.config.Configuration;
+import com.github.nhirakawa.server.guice.LocalMember;
+import com.google.inject.Inject;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+public class ClientHeaderInterceptor implements ClientInterceptor {
+
+  private final String clusterId;
+  private final String serverId;
+
+  @Inject
+  ClientHeaderInterceptor(Configuration configuration,
+                          @LocalMember ClusterMember clusterMember) {
+    this.clusterId = configuration.getClusterId();
+    this.serverId = clusterMember.getServerId();
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+                                                             CallOptions callOptions,
+                                                             Channel next) {
+    return new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        headers.put(Keys.CLUSTER_ID_KEY, clusterId);
+        headers.put(Keys.SERVER_ID_KEY, serverId);
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/Keys.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/Keys.java
@@ -1,0 +1,14 @@
+package com.github.nhirakawa.server.transport.grpc.intercept;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+
+final class Keys {
+
+  public static final Key<String> CLUSTER_ID_KEY = Key.of("X-Wilson-ClusterId", Metadata.ASCII_STRING_MARSHALLER);
+  public static final Key<String> SERVER_ID_KEY = Key.of("X-Wilson-ServerId", Metadata.ASCII_STRING_MARSHALLER);
+
+  private Keys() {
+  }
+
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/LoggingInterceptor.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/LoggingInterceptor.java
@@ -1,0 +1,49 @@
+package com.github.nhirakawa.server.transport.grpc.intercept;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+@SuppressWarnings("unused")
+public class LoggingInterceptor implements ServerInterceptor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingInterceptor.class);
+
+  private final JsonFormat.Printer printer;
+
+  @Inject
+  LoggingInterceptor(JsonFormat.Printer printer) {
+    this.printer = printer;
+  }
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                    Metadata headers,
+                                                    ServerCallHandler<ReqT, RespT> next) {
+    return new SimpleForwardingServerCallListener<ReqT>(next.startCall(call, headers)) {
+      @Override
+      public void onMessage(ReqT message) {
+        if (message.getClass().isAssignableFrom(MessageOrBuilder.class)) {
+          try {
+            LOG.info("{}", printer.print((MessageOrBuilder) message));
+          } catch (InvalidProtocolBufferException e) {
+            LOG.warn("Could not log message for type {}: {} ({})", message.getClass(), message, e.getMessage());
+          }
+        }
+
+        super.onMessage(message);
+      }
+    };
+  }
+}

--- a/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/ServerHeaderInterceptor.java
+++ b/server/src/main/java/com/github/nhirakawa/server/transport/grpc/intercept/ServerHeaderInterceptor.java
@@ -1,0 +1,41 @@
+package com.github.nhirakawa.server.transport.grpc.intercept;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+public class ServerHeaderInterceptor implements ServerInterceptor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ServerHeaderInterceptor.class);
+
+  private static final Key<String> CLUSTER_ID = Key.of("X-Wilson-ClusterId", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Key<String> SERVER_ID = Key.of("X-Wilson-ServerId", Metadata.ASCII_STRING_MARSHALLER);
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                    Metadata headers,
+                                                    ServerCallHandler<ReqT, RespT> next) {
+    Optional<String> clusterId = Optional.ofNullable(headers.get(CLUSTER_ID));
+    if (!clusterId.isPresent()) {
+      LOG.warn("clusterId not present");
+      call.close(Status.INVALID_ARGUMENT, new Metadata());
+    }
+
+    Optional<String> serverId = Optional.ofNullable(headers.get(SERVER_ID));
+    if (!serverId.isPresent()) {
+      LOG.warn("serverId not present");
+      call.close(Status.INVALID_ARGUMENT, new Metadata());
+    }
+
+    return next.startCall(call, headers);
+  }
+}

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{1} - %msg%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [%X{serverId}] %-5level %logger{1} - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Adds grpc as transport. There are tests for the core protocol, but none for the transport (may add some later). I'd also like to make the transport logic generic (and swappable) so that some other backend could be swapped in easily.